### PR TITLE
Make Image.write() accept user defined compressor.

### DIFF
--- a/visor/image/core.py
+++ b/visor/image/core.py
@@ -4,7 +4,6 @@ import json
 import zarr
 import dask.array as da
 import numcodecs
-from numcodecs import Blosc
 
 # Schema Reference: https://visor-tech.github.io/visor-data-schema
 
@@ -158,7 +157,7 @@ class Image:
     def write(self, arr:da, img_type:str, file:str,
                     resolution:int, img_info:dict,
                     arr_info:dict, selected:dict=None,
-                    compressor:numcodecs.abc.Codec = Blosc(cname='zstd', clevel=5),
+                    compressor:numcodecs.abc.Codec = numcodecs.Blosc(cname='zstd', clevel=5),
                     overwrite:bool=False):
         """
         Read Array from Image

--- a/visor/image/tests/test_core.py
+++ b/visor/image/tests/test_core.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 import unittest
 import shutil
-
+from numcodecs import Blosc
 import visor.image as vimg
 
 class TestBase(unittest.TestCase):
@@ -187,6 +187,7 @@ class TestImageWrite(TestBase):
 
     def test_image_write_compress(self):
         dst_img = vimg.open_vsr(self.dst_path, 'w')
+        compressor = Blosc(cname='zstd', clevel=5)
         dst_img.write(self.arr.array,
                       self.dst_img_type,
                       self.dst_img_file,
@@ -194,8 +195,7 @@ class TestImageWrite(TestBase):
                       self.src_img_info,
                       self.arr.info,
                       [{'path':'slice_1_10x.zarr','channels':['640']}],
-                      'blosc',
-                      {'cname':'zstd', 'clevel':5, 'shuffle':1})
+                      compressor)
         arr = dst_img.read(self.dst_img_type,
                            f'{self.dst_img_file}.zarr',
                            0)

--- a/visor/image/tests/test_core.py
+++ b/visor/image/tests/test_core.py
@@ -1,3 +1,6 @@
+# Run at root dir by
+#   python -m unittest visor/image/tests/test_core.py
+
 from pathlib import Path
 import unittest
 import shutil
@@ -182,6 +185,21 @@ class TestImageWrite(TestBase):
         self.assertEqual(arr.stack_map, {'stack_1':0, 'stack_2':1})
         self.assertEqual(arr.array.shape, (2,2,4,4,4))
 
+    def test_image_write_compress(self):
+        dst_img = vimg.open_vsr(self.dst_path, 'w')
+        dst_img.write(self.arr.array,
+                      self.dst_img_type,
+                      self.dst_img_file,
+                      self.resolution,
+                      self.src_img_info,
+                      self.arr.info,
+                      [{'path':'slice_1_10x.zarr','channels':['640']}],
+                      'blosc',
+                      {'cname':'zstd', 'clevel':5, 'shuffle':1})
+        arr = dst_img.read(self.dst_img_type,
+                           f'{self.dst_img_file}.zarr',
+                           0)
+        self.assertEqual((arr.array - self.arr.array).any().compute(), False)
 
 # class TestImageUpdate(TestBase):
 


### PR DESCRIPTION
* Now Image.write() accept a string to call registered compressors in numcodecs, this allow setup allow user defeined codecs to be accessed through numcodecs registry mechanism.
* Correct a bug in Image._get_channels().
* Allow overwrite to existing data.